### PR TITLE
update JpaConfig.java

### DIFF
--- a/profiles-and-properties/src/main/java/com/bobocode/config/JpaConfig.java
+++ b/profiles-and-properties/src/main/java/com/bobocode/config/JpaConfig.java
@@ -48,7 +48,7 @@ public class JpaConfig {
         return new HikariDataSource(config);
     }
 
-    @Bean
+    @Bean("dataSource")
     @Profile("prod")
     public HikariConfig hikariConfig() {
         HikariConfig hikariConfig = new HikariConfig();


### PR DESCRIPTION
Spring needs a bean with an exact name "dataSource". If to use @ Profile("prod") with simple @ Bean annotation then an exception occurred:
org.springframework.beans.factory.NoSuchBeanDefinitionException: No bean named 'dataSource' available